### PR TITLE
Interpret result based on the HTML page rather than the URL query

### DIFF
--- a/PayMayaSDK.podspec
+++ b/PayMayaSDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "PayMayaSDK"
-  s.version          = "0.3.6"
+  s.version          = "0.3.7"
   s.summary          = "Easily enable your iOS app to accept credit and debit card payments"
 
   s.description      = <<-DESC


### PR DESCRIPTION
This fixes:
- Status Unknown on Payment Success
- Result not closing when redirection URL is not https://paymaya.com